### PR TITLE
Add user installation support and robustness checks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # spotify_flatpak_remove_pocasts
-Script to remove podcasts from Spotify on Flatpak
 
-Needs to be run as root everytime Spotify is updated.
+Script to remove podcasts from Spotify's homepage on Flatpak. Operates on per-user Flatpak installation if Spotify is found there, system-wide installation otherwise. Will invoke sudo to operate on system-wide installation.
+
+Needs to be re-run everytime Spotify is updated.

--- a/spotify_remove_podcasts.sh
+++ b/spotify_remove_podcasts.sh
@@ -1,7 +1,34 @@
 #!/bin/sh
+# shellcheck disable=SC2094
+# Above directive is because we're not actually operating on the same file.
+set -eu
 
-cd /var/lib/flatpak/app/com.spotify.Client/current/active/files/extra/share/spotify/Apps
+# Make sure required programs are available.
+for dep in unzip zip sed; do if ! [ -x "$(command -v "$dep")" ]; then
+	printf "This script requires %s; please install it.\n" "$dep"
+	exit 1
+fi; done
+
+# Determine which Spotify to operate on.
+XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
+if [ -e "$XDG_DATA_HOME/flatpak/app/com.spotify.Client" ]; then
+	printf "Operating on per-user installation.\n"
+	target="$XDG_DATA_HOME/flatpak/app/com.spotify.Client"
+elif [ -e "/var/lib/flatpak/app/com.spotify.Client" ]; then
+	if [ "$(id -u)" -gt 0 ]; then
+		printf "Found system-wide installation as normal user; invoking sudo.\n"
+		exec sudo -k "$0"
+	else
+		printf "Operating on system-wide installation.\n"
+		target="/var/lib/flatpak/app/com.spotify.Client"
+	fi
+else
+	printf "No Flatpak Spotify installation found; exiting.\n"
+	exit 1
+fi
+
+# Actually do the thing!
+cd "$target/current/active/files/extra/share/spotify/Apps"
 unzip -p xpui.spa xpui.js | sed 's/,show,/,/' | sed 's/,episode"/"/' > xpui.js
 cp xpui.spa xpui.spa.bak
 zip xpui.spa xpui.js
-cd -


### PR DESCRIPTION
- Looks for per-user installation in XDG_DATA_HOME.
- Invokes sudo if run as normal user and only system installation is found.
- Adds `set -eu` to bail on errors as a safety measure.
- Removes redundant `cd -` before exit.
- Exits if no Flatpak installation of Spotify is found.
- Updates README.md accordingly.